### PR TITLE
Use chunkname for output filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -456,7 +456,7 @@ function bundleMain ({
       }
     ])
   }
-  config.entry('background').add(api.resolve(mainProcessFile))
+  config.entry('index').add(api.resolve(mainProcessFile))
   if (usesTypescript) {
     config.resolve.extensions.merge(['.js', '.ts'])
     config.module

--- a/index.js
+++ b/index.js
@@ -320,7 +320,7 @@ module.exports = (api, options) => {
             require('electron'),
             [
               // Have it load the main process file built with webpack
-              outputDir,
+              outputDir + '/background.js',
               // Append other arguments specified in plugin options
               ...mainProcessArgs
             ],
@@ -418,8 +418,7 @@ function bundleMain ({
 
   config.output
     .path(api.resolve(outputDir + (isBuild ? '/bundled' : '')))
-    // Electron will not detect background.js on dev server, only index.js
-    .filename(isBuild ? 'background.js' : 'index.js')
+    .filename('[name].js')
   if (isBuild) {
     //   Set __static to __dirname (files in public get copied here)
     config

--- a/index.js
+++ b/index.js
@@ -320,7 +320,7 @@ module.exports = (api, options) => {
             require('electron'),
             [
               // Have it load the main process file built with webpack
-              outputDir + '/background.js',
+              outputDir,
               // Append other arguments specified in plugin options
               ...mainProcessArgs
             ],


### PR DESCRIPTION
I changed the output filename to use the chunk's name.
Therefore I had to adjust the `launchElectron()` function to use the correct starting script.

This change makes it easier to add additional entries to the webpack config for the main process.
Those can be useful if you want to add workers which you run in the background and have to be in a separate file rather than the main bundle.

If this change gets accepted I could think of another feature:
Allowing to add additional entry scripts in a dedicated property in `electronBuilder` plugin option, similar to vue-cli's [`pages` option](https://cli.vuejs.org/config/#pages).

So far I needed to overwrite the filename in my `vue.config.js` like this:
```
pluginOptions: {
        electronBuilder: {
            ...
            chainWebpackMainProcess: config => {
                const defaultEntryFileName = config.output.get('filename')
                const fileName = function(chunkData) {
                    return chunkData.chunk.name === 'background' ? defaultEntryFileName : '[name].js';
                }

                config.output
                    .filename(fileName);
                ...
            }
      }
}
```