### PR TITLE
Kill Electron process gracefully during development

### DIFF
--- a/__tests__/commands.spec.js
+++ b/__tests__/commands.spec.js
@@ -11,6 +11,7 @@ const { chainWebpack } = require('../lib/webpackConfig')
 // #endregion
 
 // #region Mocks
+process.env.IS_TEST = true
 const mockYargsParse = jest.fn()
 const mockYargsCommand = jest.fn(() => ({ parse: mockYargsParse }))
 jest.mock('yargs', () => ({ command: mockYargsCommand }))

--- a/generator/template/src/background.js
+++ b/generator/template/src/background.js
@@ -62,9 +62,9 @@ app.on('ready', async () => {
 
 // Exit cleanly on request from parent process in development mode.
 if (isDevelopment) {
-  process.on('message', (data) => {
+  process.on('message', data => {
     if (data === 'graceful-exit') {
-      app.exit()
+      app.quit()
     }
   })
 }

--- a/generator/template/src/background.js
+++ b/generator/template/src/background.js
@@ -59,3 +59,12 @@ app.on('ready', async () => {
   }
   createWindow()
 })
+
+// Exit cleanly on request from parent process in development mode.
+if (isDevelopment) {
+  process.on('message', (data) => {
+    if (data === 'graceful-exit') {
+      app.exit()
+    }
+  })
+}

--- a/index.js
+++ b/index.js
@@ -273,14 +273,18 @@ module.exports = (api, options) => {
         }
 
         // Attempt to kill gracefully
-        child.send('graceful-exit')
+        if (typeof child.send === 'function') {
+          child.send('graceful-exit')
 
-        // Kill after 2 seconds if unsuccessful
-        childExitTimeout = setTimeout(() => {
-          if (child) {
-            child.kill()
-          }
-        }, 2000)
+          // Kill after 2 seconds if unsuccessful
+          childExitTimeout = setTimeout(() => {
+            if (child) {
+              child.kill()
+            }
+          }, 2000)
+        } else {
+          child.kill()
+        }
       }
 
       // Initial start of Electron
@@ -391,7 +395,7 @@ module.exports = (api, options) => {
               .pipe(process.stderr)
           }
 
-          child.once('exit', () => {
+          child.on('exit', () => {
             child = null
 
             if (childExitTimeout) {

--- a/index.js
+++ b/index.js
@@ -300,8 +300,8 @@ module.exports = (api, options) => {
         })
       })
 
-      // Attempt to kill gracefully on SIGINT
-      process.on('SIGINT', () => {
+      // Attempt to kill gracefully on SIGINT and SIGTERM
+      const signalHandler = () => {
         if (!child) {
           process.exit(0)
         }
@@ -310,7 +310,10 @@ module.exports = (api, options) => {
         childRestartOnExit = -1
 
         killElectron()
-      })
+      }
+
+      process.on('SIGINT', signalHandler)
+      process.on('SIGTERM', signalHandler)
 
       // Handle Ctrl+C on Windows
       if (process.platform === 'win32') {

--- a/index.js
+++ b/index.js
@@ -273,18 +273,14 @@ module.exports = (api, options) => {
         }
 
         // Attempt to kill gracefully
-        if (typeof child.send === 'function') {
-          child.send('graceful-exit')
+        child.send('graceful-exit')
 
-          // Kill after 2 seconds if unsuccessful
-          childExitTimeout = setTimeout(() => {
-            if (child) {
-              child.kill()
-            }
-          }, 2000)
-        } else {
-          child.kill()
-        }
+        // Kill after 2 seconds if unsuccessful
+        childExitTimeout = setTimeout(() => {
+          if (child) {
+            child.kill()
+          }
+        }, 2000)
       }
 
       // Initial start of Electron

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const Config = require('webpack-chain')
 const merge = require('lodash.merge')
 const fs = require('fs-extra')
 const path = require('path')
+const readline = require('readline')
 const {
   log,
   done,
@@ -310,6 +311,16 @@ module.exports = (api, options) => {
 
         killElectron()
       })
+
+      // Handle Ctrl+C on Windows
+      if (process.platform === 'win32') {
+        readline.createInterface({
+          input: process.stdin,
+          output: process.stdout
+        }).on('SIGINT', () => {
+          process.emit('SIGINT')
+        })
+      }
 
       function launchElectron () {
         if (args.debug) {

--- a/index.js
+++ b/index.js
@@ -217,12 +217,6 @@ module.exports = (api, options) => {
 
       // Copy package.json so electron can detect app's name
       fs.copySync(api.resolve('./package.json'), `${outputDir}/package.json`)
-      // Electron process
-      let child
-      // Auto restart flag
-      let childRestartOnExit = 0
-      // Graceful exit timeout
-      let childExitTimeout
 
       // Function to bundle main process and start Electron
       const startElectron = () => {
@@ -266,6 +260,12 @@ module.exports = (api, options) => {
         }
       }
 
+      // Electron process
+      let child
+      // Auto restart flag
+      let childRestartOnExit = 0
+      // Graceful exit timeout
+      let childExitTimeout
       // Function to kill Electron process
       const killElectron = () => {
         if (!child) {
@@ -317,12 +317,14 @@ module.exports = (api, options) => {
 
       // Handle Ctrl+C on Windows
       if (process.platform === 'win32') {
-        readline.createInterface({
-          input: process.stdin,
-          output: process.stdout
-        }).on('SIGINT', () => {
-          process.emit('SIGINT')
-        })
+        readline
+          .createInterface({
+            input: process.stdin,
+            output: process.stdout
+          })
+          .on('SIGINT', () => {
+            process.emit('SIGINT')
+          })
       }
 
       function launchElectron () {

--- a/index.js
+++ b/index.js
@@ -312,11 +312,11 @@ module.exports = (api, options) => {
         killElectron()
       }
 
-      process.on('SIGINT', signalHandler)
-      process.on('SIGTERM', signalHandler)
+      if (!process.env.IS_TEST) process.on('SIGINT', signalHandler)
+      if (!process.env.IS_TEST) process.on('SIGTERM', signalHandler)
 
       // Handle Ctrl+C on Windows
-      if (process.platform === 'win32') {
+      if (process.platform === 'win32' && !process.env.IS_TEST) {
         readline
           .createInterface({
             input: process.stdin,


### PR DESCRIPTION
I refactored the code to give 2 seconds to the child process to handle exiting by itself when we restart it, on SIGINT/SIGTERM and when Ctrl+C is used on Windows.

Fixes #108 