### PR TITLE
Fix IPC-related issue on non-Windows platforms

### DIFF
--- a/__tests__/commands.spec.js
+++ b/__tests__/commands.spec.js
@@ -316,6 +316,8 @@ describe('electron:build', () => {
 })
 
 describe('electron:serve', () => {
+  const isWin = process.platform === 'win32'
+
   process.env.NODE_ENV = 'development'
 
   test('typescript is disabled when set in options', async () => {
@@ -466,6 +468,7 @@ describe('electron:serve', () => {
     expect(fs.watchFile.mock.calls[0][0]).toBe('projectPath/customBackground')
     // Child has not yet been killed or unwatched
     expect(mockExeca.send).not.toBeCalled()
+    expect(mockExeca.kill).not.toBeCalled()
     expect(mockExeca.removeAllListeners).not.toBeCalled()
     // Main process was bundled and Electron was launched initially
     expect(webpack).toHaveBeenCalledTimes(1)
@@ -475,8 +478,13 @@ describe('electron:serve', () => {
     watchCb()
     childEvents.exit()
     // Electron was killed and listeners removed
-    expect(mockExeca.send).toHaveBeenCalledTimes(1)
-    expect(mockExeca.send).toHaveBeenCalledWith('graceful-exit')
+    if (isWin) {
+      expect(mockExeca.send).toHaveBeenCalledTimes(1)
+      expect(mockExeca.send).toHaveBeenCalledWith('graceful-exit')
+    } else {
+      expect(mockExeca.kill).toHaveBeenCalledTimes(1)
+      expect(mockExeca.kill).toHaveBeenCalledWith('SIGTERM')
+    }
     // Process did not exit on Electron close
     expect(process.exit).not.toBeCalled()
     // Main process file was recompiled
@@ -509,6 +517,7 @@ describe('electron:serve', () => {
     expect(fs.watchFile.mock.calls[1][0]).toBe('projectPath/listFile')
     // Child has not yet been killed or unwatched
     expect(mockExeca.send).not.toBeCalled()
+    expect(mockExeca.kill).not.toBeCalled()
     expect(mockExeca.removeAllListeners).not.toBeCalled()
     // Main process was bundled and Electron was launched initially
     expect(webpack).toHaveBeenCalledTimes(1)
@@ -518,8 +527,13 @@ describe('electron:serve', () => {
     watchCb['projectPath/listFile']()
     childEvents.exit()
     // Electron was killed and listeners removed
-    expect(mockExeca.send).toHaveBeenCalledTimes(1)
-    expect(mockExeca.send).toHaveBeenCalledWith('graceful-exit')
+    if (isWin) {
+      expect(mockExeca.send).toHaveBeenCalledTimes(1)
+      expect(mockExeca.send).toHaveBeenCalledWith('graceful-exit')
+    } else {
+      expect(mockExeca.kill).toHaveBeenCalledTimes(1)
+      expect(mockExeca.kill).toHaveBeenCalledWith('SIGTERM')
+    }
     // Process did not exit on Electron close
     expect(process.exit).not.toBeCalled()
     // Main process file was recompiled
@@ -531,8 +545,13 @@ describe('electron:serve', () => {
     watchCb['projectPath/customBackground']()
     childEvents.exit()
     // Electron was killed and listeners removed
-    expect(mockExeca.send).toHaveBeenCalledTimes(2)
-    expect(mockExeca.send).toHaveBeenCalledWith('graceful-exit')
+    if (isWin) {
+      expect(mockExeca.send).toHaveBeenCalledTimes(2)
+      expect(mockExeca.send).toHaveBeenCalledWith('graceful-exit')
+    } else {
+      expect(mockExeca.kill).toHaveBeenCalledTimes(2)
+      expect(mockExeca.kill).toHaveBeenCalledWith('SIGTERM')
+    }
     // Process did not exit on Electron close
     expect(process.exit).not.toBeCalled()
     // Main process file was recompiled

--- a/__tests__/commands.spec.js
+++ b/__tests__/commands.spec.js
@@ -316,9 +316,8 @@ describe('electron:build', () => {
 })
 
 describe('electron:serve', () => {
-  const isWin = process.platform === 'win32'
-
   process.env.NODE_ENV = 'development'
+  const isWin = process.platform === 'win32'
 
   test('typescript is disabled when set in options', async () => {
     await runCommand('electron:serve', {

--- a/generator/template/src/background.js
+++ b/generator/template/src/background.js
@@ -62,9 +62,15 @@ app.on('ready', async () => {
 
 // Exit cleanly on request from parent process in development mode.
 if (isDevelopment) {
-  process.on('message', data => {
-    if (data === 'graceful-exit') {
+  if (process.platform === 'win32') {
+    process.on('message', data => {
+      if (data === 'graceful-exit') {
+        app.quit()
+      }
+    })
+  } else {
+    process.on('SIGTERM', () => {
       app.quit()
-    }
-  })
+    })
+  }
 }


### PR DESCRIPTION
The IPC is useful on Windows to gracefully kill the child process but unnecessary on other platforms where signals can be used.

This code uses SIGTERM instead of the IPC on these platforms.

Tests are updated. I did not check the code styling (it looks consistent to me).

Fixes #117 