### PR TITLE
fix(build): update electron-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "electron-builder": "^20.28.1",
+    "electron-builder": "^20.29.0",
     "execa": "^1.0.0",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "fs-extra": "^7.0.0",


### PR DESCRIPTION
Fixes failed builds with Electron 4.0 on macOS.
Closes #123