### PR TITLE
chore(package): upgrade deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "terminal-tasks": "^0.0.4",
     "typescript": "^3.0.1",
     "vue": "^2.5.20",
-    "vue-template-compiler": "^2.5.18",
+    "vue-template-compiler": "^2.5.20",
     "vuepress": "^0.14.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^2.6.2",
     "terminal-tasks": "^0.0.4",
     "typescript": "^3.0.1",
-    "vue": "^2.5.18",
+    "vue": "^2.5.20",
     "vue-template-compiler": "^2.5.18",
     "vuepress": "^0.14.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15225,10 +15225,10 @@ vue-template-compiler@^2.5.16:
     de-indent "^1.0.2"
     he "^1.1.0"
 
-vue-template-compiler@^2.5.18:
-  version "2.5.18"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.18.tgz#8a346e477c5ada6efc890a2db4857090a2c54a05"
-  integrity sha512-WG2G+r5YxqkbTyJnbpkJuISTVI9MvYNGAZVKnmn8S4AoP0R0OufIKrHEV+GKwilLa+p3t/Plo8FzJXdhL9m4Sw==
+vue-template-compiler@^2.5.20:
+  version "2.5.20"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.20.tgz#b9c01741b7e0261d1c5aac5937c93bde98f880f0"
+  integrity sha512-aGJRLd1bJZi6oerGwCQVaDqvQ1T3dhCbNg9C2gNwzoKnyA3BmYfAWy8OQ3OhOebTri8o4YcLeXfwOOxtOKFfmA==
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -15243,10 +15243,10 @@ vue@^2.5.16:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.17.tgz#0f8789ad718be68ca1872629832ed533589c6ada"
   integrity sha512-mFbcWoDIJi0w0Za4emyLiW72Jae0yjANHbCVquMKijcavBGypqlF7zHRgMa5k4sesdv7hv2rB4JPdZfR+TPfhQ==
 
-vue@^2.5.18:
-  version "2.5.18"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.18.tgz#885586eda5c8efc77140a497500b73620e53c1dd"
-  integrity sha512-j4oT4jQdhBf3dUxzu1ogjkhzMU44AtwqtLz7oq/u7340/lmUUogTG6/D6P4/J2cCosoM21MqMIUsQchPKS4elg==
+vue@^2.5.20:
+  version "2.5.20"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.20.tgz#79fff9ccaa10cc37e7a7239b4c7adfac94df81ba"
+  integrity sha512-kVLZi8RWOk8qwAt+a0bVDy9VV5Zzcnj0fLCMyKLx1dmEBjqmYJYRWHvPwiypiJBtJkdmROy5NP5hyDqTdfBcvQ==
 
 vuepress-html-webpack-plugin@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
upgrade `vue` and `vue-template-compiler` to `2.5.20`, as `2.5.19` is broken.