### PR TITLE
Options param in testWithSpectron type definition should be optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,4 +31,4 @@ interface Server {
    Run electron:serve, but instead of launching Electron it returns a Spectron Application instance.
    Used for e2e testing with Spectron.
 */
-export function testWithSpectron(options: Options): Promise<Server>
+export function testWithSpectron(options?: Options): Promise<Server>


### PR DESCRIPTION
Since the code has a default blank object literal, the type definition should allow for no parameter to be passed.