### PR TITLE
Additional typescript definition fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ interface Server {
   /** URL of dev server. */
   url: string
   /** Close spectron and stop dev server (must be called to prevent continued async operations). */
-  stopServe: function(): Promise
+  stopServe: () => Promise<Application>
   /** Log of dev server. */
   stdout: string
 }


### PR DESCRIPTION
Fixes a couple issues with the `stopServe` typedef

* JSDoc types can only be used inside documentation comments.ts(8020)

and 

* Generic type 'Promise<T>' requires 1 type argument(s).ts(2314)