### PR TITLE
fix(build): correctly handle multiple whitelisted externals

### DIFF
--- a/__tests__/webpackConfig.spec.js
+++ b/__tests__/webpackConfig.spec.js
@@ -206,6 +206,16 @@ describe.each(['production', 'development'])('getExternals in %s', env => {
     expect(externals).toBeUndefined()
   })
 
+  test('If multiple deps are listed in user list and prefixed with "!" it should not be an external', async () => {
+    const { externals } = await mockGetExternals(
+      // Make sure it would have been marked as an external by default
+      { binary: 'It will be an external by default', name: 'mockExternal' },
+      // Add it to user externals whitelist
+      { externals: ['!mockExternal2', '!mockExternal'] }
+    )
+    expect(externals).toBeUndefined()
+  })
+
   test("Dep's package.json is read from nodeModulesPath", async () => {
     await mockGetExternals({}, { nodeModulesPath: 'customNodeModulesPath' })
 

--- a/lib/webpackConfig.js
+++ b/lib/webpackConfig.js
@@ -67,8 +67,8 @@ function getExternals (api, pluginOptions) {
     nodeModulesPaths.push(nodeModulesPath)
   }
 
-  // making a copy to avoid direct mutation
-  const userExternals = [...pluginOptions.externals] || []
+  // making a copy to avoid direct mutation of plugin options
+  const userExternals = Array.isArray(pluginOptions.externals) ? [...pluginOptions.externals] : []
   const userExternalsWhitelist = []
 
   // making copy to preserve correct index when iterating and splicing array

--- a/lib/webpackConfig.js
+++ b/lib/webpackConfig.js
@@ -66,9 +66,14 @@ function getExternals (api, pluginOptions) {
     // Add path to list
     nodeModulesPaths.push(nodeModulesPath)
   }
-  const userExternals = pluginOptions.externals || []
+
+  // making a copy to avoid direct mutation
+  const userExternals = [...pluginOptions.externals] || []
   const userExternalsWhitelist = []
-  userExternals.forEach((d, i) => {
+
+  // making copy to preserve correct index when iterating and splicing array
+  const userExternalsCopy = [...userExternals]
+  userExternalsCopy.forEach((d, i) => {
     if (d.match(/^!/)) {
       userExternals.splice(i, 1)
       userExternalsWhitelist.push(d.replace(/^!/, ''))


### PR DESCRIPTION
Resolves the issue when having multiple whitelisted externals in `pluginOptions.external` fails to correctly construct webpack `externals` config.