### PR TITLE
Update electron-builder to get Apple notarization fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "private": false,
   "dependencies": {
     "chokidar": "^2.1.5",
-    "electron-builder": "^20.29.0",
+    "electron-builder": "^20.42.0",
     "execa": "^1.0.0",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "fs-extra": "^7.0.0",


### PR DESCRIPTION
Just opening this pull request as a discussion. Hope there is a better way to handle it.

Apple recently started enforcing some notarization requirements for macOS apps. `electron-builder` package has several fixes to support this change in the recent version.

Specifying a higher version of `electron-builder` in our project installs a separate version of it where we end up with two versions of `electron-builder` in the same project. Since we run our build process using `vue-cli-service` cli, it uses `electron-builder` with the version `20.29.0`.

Even though updating `package.json` in `vue-cli-plugin-electron-builder` is the only way I found to update `electron-builder` in our project, I would love to see a better solution. Ideally, the users of `vue-cli-plugin-electron-builder` should control the version of `electron-builder` included in their project using their own `package.json`.