### PR TITLE
fix(externals): handle package names that are substrings of externals list

### DIFF
--- a/__tests__/webpackConfig.spec.js
+++ b/__tests__/webpackConfig.spec.js
@@ -196,6 +196,21 @@ describe.each(['production', 'development'])('getExternals in %s', env => {
     })
   })
 
+  test('Package names which have a substring in user externals should not be external', async () => {
+    // If user sets `express-ws` as an external, `express` should not be external
+    const { externals } = await mockGetExternals(
+      // Prevent it from getting marked as an external by default
+      {
+        main: 'It will not be an external by default',
+        name: 'mockExternal'
+      },
+      // Add string that includes package name to external list
+      { externals: ['mockExternal-special'] }
+    )
+    // External is properly added
+    expect(externals).toBeUndefined()
+  })
+
   test('If dep is listed in user list and prefixed with "!" it should not be an external', async () => {
     const { externals } = await mockGetExternals(
       // Make sure it would have been marked as an external by default

--- a/lib/webpackConfig.js
+++ b/lib/webpackConfig.js
@@ -105,7 +105,7 @@ function getExternals (api, pluginOptions) {
         }
         const pkg = JSON.parse(pgkString)
         const name = userExternals.find(name =>
-          pkg.name === name || new RegExp(`^${pkg.name}/`).test(name)
+          new RegExp(`^${pkg.name}(/|$)`).test(name)
         )
         const fields = ['main', 'module', 'jsnext:main', 'browser']
         if (

--- a/lib/webpackConfig.js
+++ b/lib/webpackConfig.js
@@ -105,7 +105,7 @@ function getExternals (api, pluginOptions) {
         }
         const pkg = JSON.parse(pgkString)
         const name = userExternals.find(name =>
-          new RegExp(`^${pkg.name}`).test(name)
+          pkg.name === name || new RegExp(`^${pkg.name}/`).test(name)
         )
         const fields = ['main', 'module', 'jsnext:main', 'browser']
         if (


### PR DESCRIPTION
The change to allow package subpaths introduced a regex which is too broad, and maps packages like `express` to `express-ws`, causing `express` to not be listed in externals. This PR fixes that while still allowing subpaths.