### PR TITLE
A local app may load resources from the internet

### DIFF
--- a/lib/createProtocol.js
+++ b/lib/createProtocol.js
@@ -7,6 +7,7 @@ export default scheme => {
   protocol.registerBufferProtocol(
     scheme,
     (request, respond) => {
+      if (request.url.startsWith('http')) return;
       let pathName = new URL(request.url).pathname
       pathName = decodeURI(pathName) // Needed in case URL contains spaces
 


### PR DESCRIPTION
A local app may load resources from the internet.
So exclude the 'http/https....' urls