### PR TITLE
Fix can't build windows package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "private": false,
   "dependencies": {
     "chokidar": "^3.0.2",
-    "electron-builder": "^21.2.0",
+    "electron-builder": "^22.2.0",
     "execa": "^1.0.0",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
When the version of electron-builder is 21.2.0, the installation package of Windows can't be built in macOS Catalina. 

### Error info:

```shell
ERROR  Error: Exit code: ENOENT. spawn prlctl ENOENT
Error: Exit code: ENOENT. spawn prlctl ENOENT
```

This error will not be present when upgrading to 22.2.0.
