### PR TITLE
fix(testWithSpectron): spectron implicitly has 'any' type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,4 +31,4 @@ interface Server {
    Run electron:serve, but instead of launching Electron it returns a Spectron Application instance.
    Used for e2e testing with Spectron.
 */
-export function testWithSpectron(spectron, options?: Options): Promise<Server>
+export function testWithSpectron(spectron: any, options?: Options): Promise<Server>


### PR DESCRIPTION
This fixes annoying error from `tsc`