### PR TITLE
feat(ui/serve): add --no-sandbox option

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -39,6 +39,20 @@ module.exports = api => {
   api.describeTask({
     match: /vue-cli-service electron:serve/,
     description: 'Serve your app, launch electron',
-    link: 'https://nklayman.github.io/vue-cli-plugin-electron-builder/'
+    link: 'https://nklayman.github.io/vue-cli-plugin-electron-builder/',
+    prompts: [
+      {
+        name: 'noSandbox',
+        type: 'confirm',
+        default: false,
+        description: 'Disable sandbox (--no-sandbox)',
+        link: 'https://github.com/electron/electron/issues/18265'
+      }
+    ],
+    onBeforeRun: ({ answers, args }) => {
+      // Args
+      if (answers.noSandbox) args.push('--no-sandbox')
+    }
+
   })
 }


### PR DESCRIPTION
On some Linux distributions the `electron:serve` task won't work without the `--no-sandbox` flag. 

see: 
https://github.com/electron/electron/issues/18265
https://github.com/electron/electron/issues/15760
https://github.com/electron/electron/issues/17972