### PR TITLE
package main/preload file

### DIFF
--- a/index.js
+++ b/index.js
@@ -579,6 +579,15 @@ function bundleMain ({
   config
     .entry(isBuild ? 'background' : 'index')
     .add(api.resolve(mainProcessFile))
+  // OK - multiple "preload" file to package
+  if (pluginOptions.mainWebpacks) {
+    let webpks = pluginOptions.mainWebpacks;
+    for (let k in webpks) {
+      config
+        .entry(k)
+        .add(api.resolve(webpks[k]))
+    }
+  }
   const {
     transformer,
     formatter


### PR DESCRIPTION
Add webpack-config to package one more "preload.js" file.
Need a file preload.js to extend windows.