### PR TITLE
fix(build): support package.json without 'dependencies' field

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,13 +157,11 @@ module.exports = (api, options) => {
         const externals = getExternals(api, pluginOptions)
         // https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/223
         // Strip non-externals from dependencies so they won't be copied into app.asar
-        if (pkg.dependencies) {
-          Object.keys(pkg.dependencies).forEach((dependency) => {
-            if (!Object.keys(externals).includes(dependency)) {
-              delete pkg.dependencies[dependency]
-            }
-          })
-        }
+        Object.keys(pkg.dependencies || {}).forEach((dependency) => {
+          if (!Object.keys(externals).includes(dependency)) {
+            delete pkg.dependencies[dependency]
+          }
+        })
         fs.writeFileSync(
           `${outputDir}/bundled/package.json`,
           JSON.stringify(pkg, 2)

--- a/index.js
+++ b/index.js
@@ -157,11 +157,13 @@ module.exports = (api, options) => {
         const externals = getExternals(api, pluginOptions)
         // https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/223
         // Strip non-externals from dependencies so they won't be copied into app.asar
-        Object.keys(pkg.dependencies).forEach((dependency) => {
-          if (!Object.keys(externals).includes(dependency)) {
-            delete pkg.dependencies[dependency]
-          }
-        })
+        if (pkg.dependencies) {
+          Object.keys(pkg.dependencies).forEach((dependency) => {
+            if (!Object.keys(externals).includes(dependency)) {
+              delete pkg.dependencies[dependency]
+            }
+          })
+        }
         fs.writeFileSync(
           `${outputDir}/bundled/package.json`,
           JSON.stringify(pkg, 2)


### PR DESCRIPTION
https://github.com/nklayman/vue-cli-plugin-electron-builder/blob/8b20b57fcb1910e75c23963eaadca8e79cf33938/index.js#L160-L164

If `pkg.dependencies` is `undefined` build failed with error:
```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at \node_modules\vue-cli-plugin-electron-builder\index.js:156:16
```