### PR TITLE
fix(webpackConfig): get electron version from deps or devDeps

### DIFF
--- a/lib/webpackConfig.js
+++ b/lib/webpackConfig.js
@@ -42,7 +42,7 @@ async function chainWebpack (api, pluginOptions, config) {
       })
       const pkg = require(api.resolve('package.json'))
       const semver = require('semver')
-      const electronVersion = pkg.devDependencies.electron
+      const electronVersion = ({...pkg.devDependencies, ...pkg.dependencies}).electron
       // Prefetch requests fail on Electron versions greater than 7
       // https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/546
       if (


### PR DESCRIPTION
When starting the server, an error occurs if the electron packet is not placed in the dependencies