### PR TITLE
docs(recipes): Updated multi platform build npm script

### DIFF
--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -398,7 +398,7 @@ To build a .deb installer for Linux and a NSIS installer for Windows:
 
 Using npm:
 
-`npm electron:build -- --linux deb --win nsis` (Do not remove the extra double dashes)
+`npm run electron:build -- --linux deb --win nsis` (Do not remove the extra double dashes)
 
 Using yarn:
 


### PR DESCRIPTION
While `yarn electron:build` is an alias for `yarn run electron:build`, `npm electron:build` is **not** an alias for `npm run electron:build`.