### PR TITLE
Update URL regex to allow missing trailing slash

### DIFF
--- a/lib/testWithSpectron.js
+++ b/lib/testWithSpectron.js
@@ -28,7 +28,7 @@ module.exports = (spectron, options = {}) =>
     child.stdout.on('data', async (data) => {
       data = data.toString()
       log += data
-      const urlMatch = data.match(/\$WEBPACK_DEV_SERVER_URL=https?:\/\/[^/]+\//)
+      const urlMatch = data.match(/\$WEBPACK_DEV_SERVER_URL=https?:\/\/[^/]+\/?/)
       const outputDirMatch = data.match(/\$outputDir=\b.*\b/)
       if (outputDirMatch) {
         // Record output dir


### PR DESCRIPTION
Summary: Allow missing trailing slash in URL regex (both ```http://localhost:8081/``` and ```http://localhost:8081``` should be accepted).

I encountered this issue after setting my webpack's devServer to the following:
```
 devServer: {
    host: "localhost",
    public: "localhost:8081",
    disableHostCheck: true
  }
```

Although this can easily be solved by adding a '/' to  ```devServer.public```, finding out that this was an issue was a real headache, because I would only receive a timeout in tests.