### PR TITLE
feat(build, serve): custom renderer entry

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -68,6 +68,22 @@ module.exports = {
 }
 ```
 
+## Change the entrypoints
+
+If you need to change the render or background scripts, you can specify them as relative paths.
+
+```javascript
+// vue.config.js
+module.exports = {
+  pluginOptions: {
+    electronBuilder: {
+      mainProcessFile: 'otherpath/background.js',
+      renderProcessFile: 'otherpath/main.js',
+    }
+  }
+}
+```
+
 ## Changing the Output Directory
 
 If you don't want your files outputted into dist_electron, you can choose a custom folder in VCPEB's plugin options. You can use the `--dest` argument to change the output dir as well.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -56,7 +56,7 @@ module.exports = {
       // Use this to change the entrypoint of your app's main process
       mainProcessFile: 'src/myBackgroundFile.js',
       // Use this to change the entry point of your app's render process. default src/[main|index].[js|ts]
-      renderProcessFile: 'src/myMainRenderFile.js',
+      rendererProcessFile: 'src/myMainRenderFile.js',
       // Provide an array of files that, when changed, will recompile the main process and restart Electron
       // Your main process file will be added by default
       mainProcessWatch: ['src/myFile1', 'src/myFile2'],

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -55,6 +55,8 @@ module.exports = {
       },
       // Use this to change the entrypoint of your app's main process
       mainProcessFile: 'src/myBackgroundFile.js',
+      // Use this to change the entry point of your app's render process. default src/[main|index].[js|ts]
+      renderProcessFile: 'src/myMainRenderFile.js',
       // Provide an array of files that, when changed, will recompile the main process and restart Electron
       // Your main process file will be added by default
       mainProcessWatch: ['src/myFile1', 'src/myFile2'],
@@ -63,22 +65,6 @@ module.exports = {
       // Note that it is ignored when --debug flag is used with "electron:serve", as you must launch Electron yourself
       // Command line args (excluding --debug, --dashboard, and --headless) are passed to Electron as well
       mainProcessArgs: ['--arg-name', 'arg-value']
-    }
-  }
-}
-```
-
-## Change the entrypoints
-
-If you need to change the render or background scripts, you can specify them as relative paths.
-
-```javascript
-// vue.config.js
-module.exports = {
-  pluginOptions: {
-    electronBuilder: {
-      mainProcessFile: 'otherpath/background.js',
-      renderProcessFile: 'otherpath/main.js',
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -37,6 +37,12 @@ module.exports = (api, options) => {
     pluginOptions.bundleMainProcess == null
       ? true
       : pluginOptions.bundleMainProcess
+  const renderProcessFileEntry =
+    pluginOptions.renderProcessFile !== undefined
+      // this argument represents argv where argv[0] is the
+      // command itself and will be shifted out
+      ? [Symbol("argv[0]"), pluginOptions.renderProcessFile]
+      : []
   if (pluginOptions.experimentalNativeDepCheck) {
     process.env.VCPEB_EXPERIMENTAL_NATIVE_DEP_CHECK = true
   }
@@ -101,7 +107,7 @@ module.exports = (api, options) => {
         const bundleOutputDir = path.join(outputDir, 'bundled')
         // Arguments to be passed to renderer build
         const vueArgs = {
-          _: [],
+          _: renderProcessFileEntry,
           // For the cli-ui webpack dashboard
           dashboard: args.dashboard,
           // Make sure files are outputted to proper directory
@@ -285,7 +291,7 @@ module.exports = (api, options) => {
 
       // Run the serve command
       const server = await api.service.run('serve', {
-        _: [],
+        _: renderProcessFileEntry,
         // Use dashboard if called from ui
         dashboard: args.dashboard,
         https: args.https

--- a/index.js
+++ b/index.js
@@ -39,9 +39,7 @@ module.exports = (api, options) => {
       : pluginOptions.bundleMainProcess
   const renderProcessFileEntry =
     pluginOptions.renderProcessFile !== undefined
-      // this argument represents argv where argv[0] is the
-      // command itself and will be shifted out
-      ? [Symbol("argv[0]"), pluginOptions.renderProcessFile]
+      ? ['First arg is removed', pluginOptions.renderProcessFile]
       : []
   if (pluginOptions.experimentalNativeDepCheck) {
     process.env.VCPEB_EXPERIMENTAL_NATIVE_DEP_CHECK = true

--- a/index.js
+++ b/index.js
@@ -37,9 +37,9 @@ module.exports = (api, options) => {
     pluginOptions.bundleMainProcess == null
       ? true
       : pluginOptions.bundleMainProcess
-  const renderProcessFileEntry =
-    pluginOptions.renderProcessFile !== undefined
-      ? ['First arg is removed', pluginOptions.renderProcessFile]
+  const rendererProcessFile =
+    pluginOptions.rendererProcessFile !== undefined
+      ? ['First arg is removed', pluginOptions.rendererProcessFile]
       : []
   if (pluginOptions.experimentalNativeDepCheck) {
     process.env.VCPEB_EXPERIMENTAL_NATIVE_DEP_CHECK = true
@@ -105,7 +105,7 @@ module.exports = (api, options) => {
         const bundleOutputDir = path.join(outputDir, 'bundled')
         // Arguments to be passed to renderer build
         const vueArgs = {
-          _: renderProcessFileEntry,
+          _: rendererProcessFile,
           // For the cli-ui webpack dashboard
           dashboard: args.dashboard,
           // Make sure files are outputted to proper directory
@@ -235,7 +235,7 @@ module.exports = (api, options) => {
           buildApp()
         }
       }
-      function buildApp () {
+      function buildApp() {
         info('Building app with electron-builder:')
         // Build the app using electron builder
         builder
@@ -289,7 +289,7 @@ module.exports = (api, options) => {
 
       // Run the serve command
       const server = await api.service.run('serve', {
-        _: renderProcessFileEntry,
+        _: rendererProcessFile,
         // Use dashboard if called from ui
         dashboard: args.dashboard,
         https: args.https
@@ -432,7 +432,7 @@ module.exports = (api, options) => {
           })
       }
 
-      async function launchElectron () {
+      async function launchElectron() {
         firstBundleCompleted = true
         // Don't exit process when electron is killed
         if (child) {
@@ -523,7 +523,7 @@ module.exports = (api, options) => {
         }
       }
 
-      function onChildExit () {
+      function onChildExit() {
         process.exit(0)
       }
     }
@@ -570,7 +570,7 @@ module.exports = (api, options) => {
   )
 }
 
-function bundleMain ({
+function bundleMain({
   mode,
   api,
   args,


### PR DESCRIPTION
I'm building multiple platforms where `src/main.js` isn't a reasonable default for me. I have my electron entrypoints in `src/platforms/desktop/main|background.ts`

This enables configuration of main and render process files, and adds documentation for for the new option. Hopefully this helps others as well!
