### PR TITLE
fix(generator): Prevent app protocol from being created multiple times

### DIFF
--- a/generator/templates/base/src/background.js
+++ b/generator/templates/base/src/background.js
@@ -8,7 +8,11 @@ const isDevelopment = process.env.NODE_ENV !== 'production'
 // Scheme must be registered before the app is ready
 protocol.registerSchemesAsPrivileged([
   { scheme: 'app', privileges: { secure: true, standard: true } }
-])
+]);
+// Protocol should be registered when not using Webpack and should only be registered once.
+if (!process.env.WEBPACK_DEV_SERVER_URL) {
+  createProtocol('app');
+}
 
 async function createWindow() {
   // Create the browser window.
@@ -27,7 +31,6 @@ async function createWindow() {
     await win.loadURL(process.env.WEBPACK_DEV_SERVER_URL)
     if (!process.env.IS_TEST) win.webContents.openDevTools()
   } else {
-    createProtocol('app')
     // Load the index.html when not in development
     win.loadURL('app://./index.html')
   }


### PR DESCRIPTION
## Description
When not using webpack, the `createProtocol` helper function is called each time a window is created. After the first call, subsequent calls fail and a message is logged to the console in response to the error.

This PR moves the logic for calling `createProtocol` to module-level scope so that this only happens once at import-time. From Electron's documentation I do not believe that this presents any issues but I definitely could be wrong.

Unfortunately I am running on a Mac so I was not able to complete all of the tests, but the only failures appear to be related to MacOS specific issues with the tests.
