### PR TITLE
feat(build): support WASM mime type

### DIFF
--- a/lib/createProtocol.js
+++ b/lib/createProtocol.js
@@ -27,6 +27,8 @@ export default scheme => {
           mimeType = 'image/svg+xml'
         } else if (extension === '.json') {
           mimeType = 'application/json'
+        } else if (extension === ".wasm") {
+          mimeType = "application/wasm";
         }
 
         respond({ mimeType, data })


### PR DESCRIPTION
When using `instantiateStreaming`, the server needs to return the correct MIME type (`application/wasm`), otherwise the WASM instantiation will fail.

In the long term I think it would be beneficial to change the `createProtocol` function and accept a second argument, which can be used to specify custom MIME types for extensions without the need to modify the `createProtocol` function itself.