### PR TITLE
fix(webpackConfig): externalize optional dependencies

### DIFF
--- a/lib/webpackConfig.js
+++ b/lib/webpackConfig.js
@@ -94,8 +94,9 @@ function getExternals (api, pluginOptions) {
     }
     return true
   })
-  const { dependencies } = require(api.resolve('./package.json'))
-  const externalsList = Object.keys(dependencies || {}).reduce(
+  const { dependencies, optionalDependencies } = require(api.resolve('./package.json'))
+  const allDependencies = Object.keys(dependencies || {}).concat(Object.keys(optionalDependencies || {}));
+  const externalsList = allDependencies.reduce(
     (depList, dep) => {
       try {
         if (process.env.VCPEB_EXPERIMENTAL_NATIVE_DEP_CHECK) {


### PR DESCRIPTION
Optional dependencies from package.json ended up being webpack'd even if specified in `externals`.