### PR TITLE
fix(build): legacy build browser version check

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ module.exports = (api, options) => {
           'report-json': args['report-json']
         }
         // With @vue/cli-service v3.4.1+, we can bypass legacy build
-        process.env.VUE_CLI_MODERN_BUILD = !args.legacy
+        process.env.VUE_CLI_MODERN_BUILD = !args.legacy || ''
         // If the legacy builded is skipped the output dir won't be cleaned
         fs.removeSync(bundleOutputDir)
         fs.ensureDirSync(bundleOutputDir)


### PR DESCRIPTION
Package `@vue/cli-service` and some other packages using `!process.env.VUE_CLI_MODERN_BUILD` for modern build check, so empty string `''` should be used instead of `false`.

This fixes browser version check and maybe some other features when building legacy app.