### PR TITLE
fix(createProtocol): ProtocolDeprecateCallback

### DIFF
--- a/lib/createProtocol.js
+++ b/lib/createProtocol.js
@@ -36,11 +36,6 @@ export default (scheme) => {
 
         respond({ mimeType, data })
       })
-    },
-    (error) => {
-      if (error) {
-        console.error(`Failed to register ${scheme} protocol`, error)
-      }
     }
   )
 }


### PR DESCRIPTION
registerBufferProtocol is now synchronous as of Electron 7  and the final callback argument is deprecated.

See: https://github.com/electron/electron/blob/7-0-x/docs/api/breaking-changes-ns.md

This fixes the warnings:

`ProtocolDeprecateCallback: The callback argument of protocol module APIs is no longer needed.`