### PR TITLE
feat(build): add arg to skip electron-builder

### DIFF
--- a/__tests__/commands.spec.js
+++ b/__tests__/commands.spec.js
@@ -228,6 +228,7 @@ describe('electron:build', () => {
     ['--legacy'],
     ['--dashboard'],
     ['--skipBundle'],
+    ['--skipElectronBuild']
     ['--dest', 'output'],
     ['--report'],
     ['--report-json']

--- a/__tests__/commands.spec.js
+++ b/__tests__/commands.spec.js
@@ -228,7 +228,7 @@ describe('electron:build', () => {
     ['--legacy'],
     ['--dashboard'],
     ['--skipBundle'],
-    ['--skipElectronBuild']
+    ['--skipElectronBuild'],
     ['--dest', 'output'],
     ['--report'],
     ['--report-json']

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ module.exports = (api, options) => {
       removeArg('--legacy', 1, rawArgs)
       removeArg('--dashboard', 1, rawArgs)
       removeArg('--skipBundle', 1, rawArgs)
+      removeArg('--skipElectronBuild', 1, rawArgs)
       removeArg('--report', 1, rawArgs)
       removeArg('--report-json', 1, rawArgs)
       // Parse the raw arguments using electron-builder yargs config
@@ -100,7 +101,7 @@ module.exports = (api, options) => {
       if (args.skipBundle) {
         console.log('Not bundling app as --skipBundle was passed')
         // Build with electron-builder
-        buildApp()
+        buildApp(args.skipElectronBuild)
       } else {
         const bundleOutputDir = path.join(outputDir, 'bundled')
         // Arguments to be passed to renderer build
@@ -217,10 +218,10 @@ module.exports = (api, options) => {
                 )
                 log(formatStats(stats, targetDirShort, api))
 
-                buildApp()
+                buildApp(skipElectronBuild)
               })
             } else {
-              buildApp()
+              buildApp(skipElectronBuild)
             }
           })
         } else {
@@ -232,10 +233,11 @@ module.exports = (api, options) => {
             api.resolve(mainProcessFile),
             api.resolve(`${outputDir}/bundled/background.js`)
           )
-          buildApp()
+          buildApp(skipElectronBuild)
         }
       }
-      function buildApp () {
+      function buildApp (skip) {
+        if (skip) return
         info('Building app with electron-builder:')
         // Build the app using electron builder
         builder

--- a/index.js
+++ b/index.js
@@ -237,7 +237,10 @@ module.exports = (api, options) => {
         }
       }
       function buildApp (skip) {
-        if (skip) return
+        if (skip) {
+          console.log('Not building app as --skipElectronBuild was passed')
+          return
+        }
         info('Building app with electron-builder:')
         // Build the app using electron builder
         builder

--- a/index.js
+++ b/index.js
@@ -218,10 +218,10 @@ module.exports = (api, options) => {
                 )
                 log(formatStats(stats, targetDirShort, api))
 
-                buildApp(skipElectronBuild)
+                buildApp(args.skipElectronBuild)
               })
             } else {
-              buildApp(skipElectronBuild)
+              buildApp(args.skipElectronBuild)
             }
           })
         } else {
@@ -233,7 +233,7 @@ module.exports = (api, options) => {
             api.resolve(mainProcessFile),
             api.resolve(`${outputDir}/bundled/background.js`)
           )
-          buildApp(skipElectronBuild)
+          buildApp(args.skipElectronBuild)
         }
       }
       function buildApp (skip) {


### PR DESCRIPTION
Adding functionality to include a `--skipElectronBuilder` flag to allow for bundle process to complete without having to fully build an executable.  This would allow developers/maintainers to have custom build/packaging solutions outside of the currently prescribed process in this plugin.

https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/1161