### PR TITLE
fix(build): Format properly generated package.json

### DIFF
--- a/__tests__/commands.spec.js
+++ b/__tests__/commands.spec.js
@@ -380,7 +380,7 @@ describe('electron:build', () => {
         dependencies: {
           external: '^0.0.1'
         }
-      })
+      }, undefined, 2)
     )
   })
 

--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ module.exports = (api, options) => {
         })
         fs.writeFileSync(
           `${outputDir}/bundled/package.json`,
-          JSON.stringify(pkg, 2)
+          JSON.stringify(pkg, null, 2)
         )
         // Prevent electron-builder from installing app deps
         fs.ensureDirSync(`${outputDir}/bundled/node_modules`)


### PR DESCRIPTION
Hi,
Thanks for you work.

The second argument is the replacer, the third the number of spaces:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify