### PR TITLE
chore(types): add plugin options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,7 @@
 import { Application, AppConstructorOptions } from 'spectron'
+import { Configuration as ElectronBuilderOptions } from 'electron-builder'
+import * as ChainableWebpackConfig from 'webpack-chain'
+
 interface Options {
   /**
    Do not launch spectron.
@@ -32,3 +35,22 @@ interface Server {
    Used for e2e testing with Spectron.
 */
 export function testWithSpectron(spectron: any, options?: Options): Promise<Server>
+
+  
+export type PluginOptions = {
+  builderOptions?: ElectronBuilderOptions,
+  chainWebpackMainProcess?: (config?: ChainableWebpackConfig) => void,
+  chainWebpackRendererProcess?: (config?: ChainableWebpackConfig) => void,
+  mainProcessFile?: string,
+  rendererProcessFile?: string,
+  mainProcessWatch?: string[],
+  mainProcessArgs?: string[],
+  outputDir?: string,
+  disableMainProcessTypescript?: boolean,
+  mainProcessTypeChecking?: boolean,
+  customFileProtocol?: string,
+  removeElectronJunk?: boolean,
+  externals?: string[],
+  nodeModulesPath?: string[],
+  preload?: string | Record<string, string>
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-rc.6",
   "description": "Easily Build Your Vue.js App For Desktop With Electron",
   "main": "index.js",
+  "types": "index.d.ts",
   "homepage": "https://nklayman.github.io/vue-cli-plugin-electron-builder/",
   "funding": "https://github.com/sponsors/nklayman",
   "scripts": {


### PR DESCRIPTION
Hi, 
I use a vue.config.ts file to have type checking and autocompletion in my config.

So I added the types of the plugin config in this PR.

I may have missed some of them, I've just dug in the doc to find all the config keys and their type. (It might be handy to write this object in the doc, and add comments).

Thanks for your amazing work on this plugin.