### PR TITLE
fix(testWithSpectron): options type should be Partial<>

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ interface Options {
   /** Launch server in dev mode, not in production. */
   forceDev: boolean
   /** Custom spectron options.These will be merged with default options. */
-  spectronOptions: Partial<AppConstructorOptions>
+  spectronOptions: AppConstructorOptions
   /** Do not start app or wait for it to load.
    You will have to run app.start() and app.client.waitUntilWindowLoaded() yourself.
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ interface Options {
   /** Launch server in dev mode, not in production. */
   forceDev: boolean
   /** Custom spectron options.These will be merged with default options. */
-  spectronOptions: AppConstructorOptions
+  spectronOptions: Partial<AppConstructorOptions>
   /** Do not start app or wait for it to load.
    You will have to run app.start() and app.client.waitUntilWindowLoaded() yourself.
    */
@@ -34,7 +34,7 @@ interface Server {
    Run electron:serve, but instead of launching Electron it returns a Spectron Application instance.
    Used for e2e testing with Spectron.
 */
-export function testWithSpectron(spectron: any, options?: Options): Promise<Server>
+export function testWithSpectron(spectron: any, options?: Partial<Options>): Promise<Server>
 
   
 export type PluginOptions = {


### PR DESCRIPTION
Today, the `options` is optional, but only it. It means that if you want to set one option property, you have to set them all (in *TypeScript*).

For example, I commented out the `spectronOptions` property, and I get an error because it is missing:
```bash
test/e2e/specs/launch.spec.ts:28:64 - error TS2345: Argument of type '{ noSpectron: false; noStart: false; forceDev: false; mode: string; }' is not assignable to parameter of type 'Options'.
  Property 'spectronOptions' is missing in type '{ noSpectron: false; noStart: false; forceDev: false; mode: string; }' but required in type 'Options'.

 28     ({ app, stopServe, stdout } = await testWithSpectron(appi, {
                                                                   ~
 29       noSpectron: false,
    ~~~~~~~~~~~~~~~~~~~~~~~~
... 
 33       // spectronOptions: {}
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 34     }));
    ~~~~~
```