### PR TITLE
Updating electron-devtools-installer to ^3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "electron": "^13.1.4",
-    "electron-devtools-installer": "^3.1.0",
+    "electron-devtools-installer": "^3.1.1",
     "eslint": "^7.2.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.21.2",


### PR DESCRIPTION
Related issue: https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/1469

Related fix: https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/2577#issuecomment-730378777