### PR TITLE
Update testWithSpectron to testWithPlaywright

### DIFF
--- a/lib/webpackConfig.js
+++ b/lib/webpackConfig.js
@@ -55,8 +55,8 @@ async function chainWebpack (api, pluginOptions, config) {
       .use('shebang')
       .loader('shebang-loader')
     config.externals({
-      'vue-cli-plugin-electron-builder/lib/testWithSpectron':
-        'require("vue-cli-plugin-electron-builder/lib/testWithSpectron")',
+      'vue-cli-plugin-electron-builder/lib/testWithPlaywright':
+        'require("vue-cli-plugin-electron-builder/lib/testWithPlaywright")',
       'vue-cli-plugin-electron-builder':
         'require("vue-cli-plugin-electron-builder")'
     })


### PR DESCRIPTION
In the 3.0.0-alpha.3 release the entire if statement was commented out. That resulted in the mocha test not running. By uncommenting the code and updating it to PlayWright I got my mocha tests running.

I can't find the code being commented out on the v3 branch, but please make sure it isn't commented out.