### PR TITLE
(actions) update set-output

### DIFF
--- a/.github/workflows/nodeCI.yml
+++ b/.github/workflows/nodeCI.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: ${{ matrix.node }}
     - name: Get yarn cache dir
       id: yarn-cache
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Yarn cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/nodeCI.yml
+++ b/.github/workflows/nodeCI.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: ${{ matrix.node }}
     - name: Get yarn cache dir
       id: yarn-cache
-      run: echo "dir=$(yarn cache dir)" >> ${Env:GITHUB_OUTPUT}
+      run: echo "dir=$(yarn cache dir)" >> $env:GITHUB_OUTPUT
     - name: Yarn cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/nodeCI.yml
+++ b/.github/workflows/nodeCI.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: ${{ matrix.node }}
     - name: Get yarn cache dir
       id: yarn-cache
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      run: echo "dir=$(yarn cache dir)" >> ${Env:GITHUB_OUTPUT}
     - name: Yarn cache
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/