### PR TITLE
Added powershell GH_TOKEN environment variable instruction

### DIFF
--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -72,7 +72,9 @@ On Linux/MacOS:
 
 On Windows:
 
-`set GH_TOKEN=TOKEN-GOES-HERE`
+CMD: `set GH_TOKEN=TOKEN-GOES-HERE`
+
+Powershell: `$env:GH_TOKEN = 'TOKEN-GOES-HERE'`
 
 ### Upload Release to GitHub
 


### PR DESCRIPTION
`set GH_TOKEN=TOKEN-GOES-HERE` does not work in powershell. So, I added the instruction. 